### PR TITLE
fix(spawn): unusable camera rotations upon character creation

### DIFF
--- a/client/apartmentselect.lua
+++ b/client/apartmentselect.lua
@@ -157,7 +157,6 @@ end
 function StopCamera()
     SetCamActive(previewCam, false)
     DestroyCam(previewCam, true)
-    RenderScriptCams(false, false, 1, true, true)
 end
 
 function ManagePlayer()


### PR DESCRIPTION
## Description

(fixes unuseable illenium-appearance camera modes during character creation)

after some headache with the many cameras in different resources looks like the `RenderScriptCams` native is being called redundantly, thus messing with the `illenium-appearance` camera rotations becoming unusable [initial report link](https://discord.com/channels/1012753553418354748/1247986887990448199/1247986887990448199)

_(Video evidence provided by `@Shomy`)_
https://medal.tv/games/gta-v/clips/i0CINqUIGSTbC71-d/d1337j6DAPtg?invite=cr-MSxrYWksMjAzODYyODIwLA

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
