### PR TITLE
fix(client/apartmentselect): use RegisterNetEvent

### DIFF
--- a/client/apartmentselect.lua
+++ b/client/apartmentselect.lua
@@ -203,7 +203,7 @@ local function InputHandler()
     StopCamera()
 end
 
-AddEventHandler('apartments:client:setupSpawnUI', function()
+RegisterNetEvent('apartments:client:setupSpawnUI', function()
     Wait(400)
     ManagePlayer()
     SetupCamera(true)


### PR DESCRIPTION
I guess people trigger this from the server side

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
