### PR TITLE
feat: make use of currentPropertyId

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -29,7 +29,7 @@ server_scripts {
     'server/apartmentselect.lua',
     'server/property.lua',
     'server/realtor.lua',
-    'server/decorating.js'
+    --'server/decorating.js' only used for taking screenshots of furniture
 }
 
 files {

--- a/server/apartmentselect.lua
+++ b/server/apartmentselect.lua
@@ -1,8 +1,8 @@
 RegisterNetEvent('qbx_properties:server:apartmentSelect', function(apartmentIndex)
     local playerSource = source --[[@as number]]
     local player = exports.qbx_core:GetPlayer(playerSource)
-
     if not ApartmentOptions[apartmentIndex] then return end
+
     local hasApartment = MySQL.single.await('SELECT * FROM properties WHERE owner = ?', {player.PlayerData.citizenid})
     if hasApartment then return end
 
@@ -29,7 +29,7 @@ RegisterNetEvent('qbx_properties:server:apartmentSelect', function(apartmentInde
         }
     }
 
-    local result = MySQL.single.await('SELECT id FROM properties ORDER BY id DESC', {})
+    local result = MySQL.single.await('SELECT id FROM properties ORDER BY id DESC')
     local apartmentNumber = result?.id or 0
 
     ::again::
@@ -47,7 +47,7 @@ RegisterNetEvent('qbx_properties:server:apartmentSelect', function(apartmentInde
         json.encode(stashData),
     })
 
-    TriggerClientEvent('qb-clothes:client:CreateFirstCharacter', playerSource)
     TriggerClientEvent('qbx_properties:client:addProperty', -1, ApartmentOptions[apartmentIndex].enter)
-    EnterProperty(playerSource, id)
+    TriggerClientEvent('qb-clothes:client:CreateFirstCharacter', playerSource)
+    EnterProperty(playerSource, id, true)
 end)


### PR DESCRIPTION
## Description

This PR makes use of currentPropertyId to be used with qbx_spawn.
Also added lib.triggerClientEvent for events that loop over an array. lib.triggerClientEvent already does this so it cleans up the code a little.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
