### PR TITLE
fix(client/apartmentselect): explicitly define streaming asset timeouts

### DIFF
--- a/client/apartmentselect.lua
+++ b/client/apartmentselect.lua
@@ -5,7 +5,7 @@ local Board, scaleform, buttonsScaleform, currentButtonID = nil, 0, 0, 1
 local previewCam
 
 local function SetupBoard()
-    lib.requestModel(BoardModel)
+    lib.requestModel(BoardModel, 10000)
     Board = CreateObject(BoardModel, BoardCoords.x, BoardCoords.y, BoardCoords.z, false, false, false)
     SetEntityHeading(Board, BoardCoords.w)
     SetModelAsNoLongerNeeded(BoardModel)
@@ -61,8 +61,8 @@ local function CreateNamedRenderTargetForModel(name, model)
 end
 
 local function StartScaleform()
-    scaleform = lib.requestScaleformMovie('AUTO_SHOP_BOARD') or 0
-    buttonsScaleform = lib.requestScaleformMovie('INSTRUCTIONAL_BUTTONS') or 0
+    scaleform = lib.requestScaleformMovie('AUTO_SHOP_BOARD', 10000) or 0
+    buttonsScaleform = lib.requestScaleformMovie('INSTRUCTIONAL_BUTTONS', 10000) or 0
     CreateThread(function()
         SetupInstructionalScaleform()
         while DoesCamExist(previewCam) do


### PR DESCRIPTION
For those with potatoes for computers this should be set to higher than the ox_lib default of 1000.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Fixes timeout issues for low performance PCs

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
