### PR TITLE
Fix camera freeze issue after apartment selection

### DIFF
--- a/client/apartmentselect.lua
+++ b/client/apartmentselect.lua
@@ -157,8 +157,12 @@ function SetupCamera(apartmentCam)
 end
 
 function StopCamera()
-    SetCamActive(previewCam, false)
-    DestroyCam(previewCam, true)
+    if DoesCamExist(previewCam) then
+        SetCamActive(previewCam, false)
+        RenderScriptCams(false, false, 0, true, true)
+        DestroyCam(previewCam, true)
+        previewCam = nil
+    end
 end
 
 function ManagePlayer()


### PR DESCRIPTION
## Description
In the current version, the functionality relies on a subsequent call to ```qb-clothes:client:CreateFirstCharacter```. If a custom clothing event is used and this event is not triggered, it may result in an abnormal player camera view.
The primary fix involves enhancing the StopCamera function to ensure the preview camera is completely deactivated and destroyed, preventing any leftover camera resources from causing view issues

## Checklist


- [x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x ] My pull request fits the contribution guidelines & code conventions.
