### PR TITLE
fix(server): create SQL table immediately

### DIFF
--- a/server/property.lua
+++ b/server/property.lua
@@ -402,7 +402,7 @@ RegisterNetEvent('qbx_properties:server:buyProperty', function(propertyId)
     exports.qbx_core:Notify(playerSource, string.format('Successfully purchased %s for $%s', property.property_name, property.price))
 end)
 
-CreateThread(function()
+Citizen.CreateThreadNow(function()
     local sql1 = LoadResourceFile(cache.resource, 'property.sql')
     local sql2 = LoadResourceFile(cache.resource, 'decorations.sql')
     MySQL.query.await(sql1)


### PR DESCRIPTION
## Description

Sometimes this can be executed after qbx_core checks for tables, which causes a warning that the `properties` table does not exist.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
