### PR TITLE
feat(client): Show Selection on Map

### DIFF
--- a/client/apartmentselect.lua
+++ b/client/apartmentselect.lua
@@ -186,14 +186,28 @@ local function inputConfirm(apartmentIndex)
 end
 
 local function InputHandler()
+    local coords = sharedConfig.apartmentOptions[currentButtonID].enter
+    local blip = AddBlipForCoord(coords.x, coords.y, coords.z)
+    SetBlipSprite(blip, 40)
+    ShowTickOnBlip(blip, true)
+    LockMinimapAngle(0.0)
     while true do
+        SetBigmapActive(true, false)
+        DisplayRadar(true)
+        SetRadarAsExteriorThisFrame()
         if IsControlJustReleased(0, 188) then
             currentButtonID -= 1
             if currentButtonID < 1 then currentButtonID = #sharedConfig.apartmentOptions end
+            coords = sharedConfig.apartmentOptions[currentButtonID].enter
+            SetBlipCoords(blip, coords.x, coords.y, coords.z)
+            LockMinimapPosition(coords.x, coords.y)
             SetupScaleform()
         elseif IsControlJustReleased(0, 187) then
             currentButtonID += 1
             if currentButtonID > #sharedConfig.apartmentOptions then currentButtonID = 1 end
+            coords = sharedConfig.apartmentOptions[currentButtonID].enter
+            SetBlipCoords(blip, coords.x, coords.y, coords.z)
+            LockMinimapPosition(coords.x, coords.y)
             SetupScaleform()
         elseif IsControlJustReleased(0, 191) then
             local alert = lib.alertDialog({
@@ -209,6 +223,11 @@ local function InputHandler()
         end
         Wait(0)
     end
+    SetBigmapActive(false, false)
+    DisplayRadar(false)
+    RemoveBlip(blip)
+    UnlockMinimapPosition()
+    UnlockMinimapAngle()
     StopCamera()
 end
 


### PR DESCRIPTION
## Description
This feature shows a user where exactly on the map his selection for apartment would be, useful for those who dont know exactly where the GTA Online apartments are located.

## Small Issue
~~One small issue is one I bought up [here](https://discord.com/channels/1012753553418354748/1290917773454737458/1329314862194622528) (qbox contributors channel) is the `qbx_hud` currently has a thread every 500ms to disable the big map. Without its removal it causes the map to flicker in this selection screen~~ No issues, Hud PR Merged

## Preview
![image](https://github.com/user-attachments/assets/f4c9fd5a-394b-41c4-86f2-cd81df646ad9)

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.

## Requirements
`qbx_hud` PR: https://github.com/Qbox-project/qbx_hud/pull/33
