### PR TITLE
Fix for optional garages.

### DIFF
--- a/client/realtor.lua
+++ b/client/realtor.lua
@@ -129,14 +129,21 @@ lib.registerMenu({
     })
     if not input then return end
 
+    local garageData = nil
+    
     if input[4] then
         addGaragePoint()
+        if garageCoords then
+            garageData = vec4(garageCoords.x, garageCoords.y, garageCoords.z + 1.0, garageHeading)
+        end
     end
-    TriggerServerEvent('qbx_properties:server:createProperty', args[scrollIndex], input, playerCoords, vec4(garageCoords.x, garageCoords.y, garageCoords.z + 1.0, garageHeading))
+
+    TriggerServerEvent('qbx_properties:server:createProperty', args[scrollIndex], input, playerCoords, garageData)
 end)
 
 RegisterNetEvent('qbx_properties:client:createProperty', function()
     playerCoords = GetEntityCoords(cache.ped)
+    garageCoords = nil
     isPreviewing = true
     previewProperty(values[1])
     lib.showMenu('qbx_properties_realtor_menu')


### PR DESCRIPTION
## Description

The createProperty event form has a checkbox for an optional garage, but if no garage is added, it causes an error and the property cannot be created. This patch fixes that by respecting the unchecked field and conditionally saving the garageCoords as nil or the vec4.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
