### PR TITLE
Add "firstspawn" ped config (Apartment exit/menu UI conflict)

### DIFF
--- a/config/shared.lua
+++ b/config/shared.lua
@@ -42,54 +42,63 @@ return {
 
     interiors = {
         [`furnitured_midapart`] = {
+			firstspawn = vec3(1.46, -10.33, 0.0),
             exit = vec3(1.46, -10.33, 0.0),
             clothing = vec3(6.03, 9.3, 0.0),
             stash = vec3(6.91, 3.94, 0.0),
             logout = vec3(4.07, 7.89, 0.0)
         },
         ['4IntegrityWayApt28'] = {
-            exit = vec4(-30.58, -595.4, 80.03, 246.95),
-            clothing = vec3(-38.25, -589.71, 78.83),
-            stash = vec3(-12.1, -598.26, 79.43),
-            logout = vec3(-37.14, -583.65, 78.83)
+			firstspawn = vec4(-26.66, -596.81, 79.03, 67.54), -- Defines the location of the first player ped spawn inside an apartment (character clothing/body customisation)
+            exit = vec4(-30.58, -595.4, 80.03, 246.95), -- Defines player apartment exit/apartment menu location
+            clothing = vec3(-38.25, -589.71, 78.83), -- Defines apartment clothing menu location
+            stash = vec3(-12.1, -598.26, 79.43), -- Defines apartment stash menu location
+            logout = vec3(-37.14, -583.65, 78.83) -- Defines apartment logout menu location
         },
         ['4IntegrityWayApt30'] = {
+			firstspawn = vec4(-15.94, -583.62, 89.11, 157.65),
             exit = vec4(-17.41, -588.17, 90.11, 338.23),
             clothing = vec3(-38.11, -583.48, 83.92),
             stash = vec3(-26.95, -588.61, 90.12),
             logout = vec3(-37.28, -577.89, 83.91)
         },
         ['DellPerroHeightsApt4'] = {
+			firstspawn = vec4(-1454.73, -537.03, 73.04, 212.89),
             exit = vec4(-1453.02, -539.5, 74.04, 35.33),
             clothing = vec3(-1449.88, -549.25, 72.84),
             stash = vec3(-1466.83, -527.03, 73.44),
             logout = vec3(-1454.08, -553.25, 72.84)
         },
         ['DellPerroHeightsApt7'] = {
+			firstspawn = vec4(-1457.03, -524.08, 55.93, 123.32),
             exit = vec3(-1458.5, -520.89, 56.93),
             clothing = vec3(-1467.46, -537.28, 50.73),
             stash = vec3(-1457.44, -531.26, 56.94),
             logout = vec3(-1471.83, -533.47, 50.72)
         },
         ['RichardMajesticApt2'] = {
+			firstspawn = vec4(-916.66, -367.19, 113.27, 294.44),
             exit = vec4(-913.99, -365.81, 114.27, 115.17),
             clothing = vec3(-903.79, -363.99, 113.07),
             stash = vec3(-928.04, -377.22, 113.67),
             logout = vec3(-900.27, -368.65, 113.07)
         },
         ['TinselTowersApt42'] = {
+			firstspawn = vec4(-607.7, 58.84, 97.2, 264.63),
             exit = vec4(-604.06, 58.99, 98.2, 91.45),
             clothing = vec3(-594.63, 56.15, 97.0),
             stash = vec3(-622.36, 55.09, 97.6),
             logout = vec3(-593.71, 50.18, 97.0)
         },
         ['GTAOHouseMid1'] = {
+			firstspawn = vec4(346.71, -1008.01, -100.2, 177.48),
             exit = vec4(346.76, -1011.52, -99.2, 358.57),
             clothing = vec3(350.84, -993.9, -99.2),
             stash = vec3(351.98, -998.8, -99.2),
             logout = vec3(349.24, -995.09, -99.2)
         },
         ['GTAOHouseLow1'] = {
+			firstspawn = vec4(259.66, -1003.63, -100.01, 296.47),
             exit = vec4(266.2, -1007.03, -100.92, 6.02),
             clothing = vec3(260.4, -1003.27, -99.01),
             stash = vec3(265.96, -999.37, -99.01),

--- a/server/apartmentselect.lua
+++ b/server/apartmentselect.lua
@@ -60,6 +60,13 @@ RegisterNetEvent('qbx_properties:server:apartmentSelect', function(apartmentInde
 
     TriggerClientEvent('qbx_properties:client:addProperty', -1, sharedConfig.apartmentOptions[apartmentIndex].enter)
     EnterProperty(playerSource, id, true)
+    
+    local interior = sharedConfig.apartmentOptions[apartmentIndex].interior
+	local spawnCoord = sharedConfig.interiors[interior].firstspawn
+	local ped = GetPlayerPed(playerSource)
+	SetEntityCoords(ped, spawnCoord.x, spawnCoord.y, spawnCoord.z, false, false, false, false)
+	SetEntityHeading(ped, spawnCoord.w)
+        
     Wait(200)
     TriggerClientEvent('qb-clothes:client:CreateFirstCharacter', playerSource)
 end)

--- a/server/apartmentselect.lua
+++ b/server/apartmentselect.lua
@@ -61,7 +61,6 @@ RegisterNetEvent('qbx_properties:server:apartmentSelect', function(apartmentInde
     TriggerClientEvent('qbx_properties:client:addProperty', -1, sharedConfig.apartmentOptions[apartmentIndex].enter)
     EnterProperty(playerSource, id, true)
     
-    local interior = sharedConfig.apartmentOptions[apartmentIndex].interior
 	local spawnCoord = sharedConfig.interiors[interior].firstspawn
 	local ped = GetPlayerPed(playerSource)
 	SetEntityCoords(ped, spawnCoord.x, spawnCoord.y, spawnCoord.z, false, false, false, false)


### PR DESCRIPTION
## Description

Currently when a player creates a new character and are using starting apartments, the ped is spawned at the exit config vector, this then opens the illenium-appearance character creation menu, while the "Exit [E] | [G] Manage" apartment menu appears during body/clothing selection.

This PR adds a new config for "firstspawn" so that server owners can adjust the initial ped spawn instead of working off the exit config.

<img width="1263" height="775" alt="image" src="https://github.com/user-attachments/assets/31fceedb-c05e-4cb2-8f02-88c0c43fcab9" />

## Checklist

- [ X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ X] My pull request fits the contribution guidelines & code conventions.

Notes:
The only interior I couldn't see myself or work out how to get into to change the vector was the first one, so I left this with the same vec3 as exit:
```lua
[`furnitured_midapart`] = {
			firstspawn = vec3(1.46, -10.33, 0.0),
            exit = vec3(1.46, -10.33, 0.0),
            clothing = vec3(6.03, 9.3, 0.0),
            stash = vec3(6.91, 3.94, 0.0),
            logout = vec3(4.07, 7.89, 0.0)
        },```

To test, I went through all 5 apartments and made a new character each time and saved the appearance and then exited the apartment and entered again, all work as intended.

Any feedback on the changes for structure and such just let me know.