### PR TITLE
Fix: open stash exploit

### DIFF
--- a/server/property.lua
+++ b/server/property.lua
@@ -7,6 +7,21 @@ local insideProperty = {}
 local citizenid = {}
 local ring = {}
 
+exports.ox_inventory:registerHook('openInventory', function(payload)
+    local source = payload.source
+    local propertyName, ownerIdentifier = payload.inventoryId:match("^qbx_properties_([%w%s]+):([A-Z%d]+)$")
+
+    if not enteredProperty[source] then return false end
+
+    local result = MySQL.single.await('SELECT `id` FROM `properties` WHERE `property_name` = ? AND `owner` = ?', {propertyName, ownerIdentifier})
+
+    return result.id == enteredProperty[source]
+end, {
+    inventoryFilter = {
+        '^qbx_properties_[%w]+',
+    }
+})
+
 function EnterProperty(playerSource, id, isSpawn)
     local property = MySQL.single.await('SELECT * FROM properties WHERE id = ?', {id})
     if not property then return end -- Lua and its stupid need check nil warnings


### PR DESCRIPTION
## Description

The current version of this script allows any malicious actor to open any stash on the server without ever entering the property. This is due to an incorrect belief that ox_inventory's RegisterStash owner arg acts as an access control measure, when in it's intended to work as a lookup key for easier deletion of stashes.

To resolve this exploit, I added a hook on the openInventory event so that it can run extra checks before authorising the opening of the inventory, it checks the following:
* is the player in a property - via the `enteredProperty` table
* is the opened stash property's id the same as the one the player is in

To avoid breaking changes and adding more variables I opted in using a database query to get the property id from the stashes name using patterns to extract the name and owner of the property. This is open to debate on how to improve it if deemed to expensive as the `property_name` column is not indexed.